### PR TITLE
Added flags to ScyllaDB and Manager to be able to test pre-released versions

### DIFF
--- a/hack/.ci/lib/e2e.sh
+++ b/hack/.ci/lib/e2e.sh
@@ -274,6 +274,11 @@ spec:
     - "--object-storage-bucket=${SO_BUCKET_NAME}"
     - "--gcs-service-account-key-path=${gcs_sa_in_container_path}"
     - "--s3-credentials-file-path=${s3_credentials_in_container_path}"
+    - "--scylla-db-version=${SCYLLA_DB_VERSION}"
+    - "--scylla-manager-version=${SCYLLA_MANAGER_VERSION}"
+    - "--scylla-manager-agent-version=${SCYLLA_MANAGER_AGENT_VERSION}"
+    - "--scylla-update-from=${SCYLLA_UPDATE_FROM}"
+    - "--scylla-upgrade-from=${SCYLLA_UPGRADE_FROM}"
     image: "${SO_IMAGE}"
     imagePullPolicy: Always
     volumeMounts:

--- a/hack/ci-deploy-release.sh
+++ b/hack/ci-deploy-release.sh
@@ -275,6 +275,51 @@ target:
 EOF
 fi
 
+if [[ -n "${SCYLLA_DB_VERSION:-}" ]]; then
+  cat << EOF | \
+  yq eval-all --inplace 'select(fileIndex == 0) as $f | select(fileIndex == 1) as $p | with( $f.patches; . += $p | ... style="") | $f' "${ARTIFACTS_DEPLOY_DIR}/manager/kustomization.yaml" -
+patch: |-
+  - op: replace
+    path: /spec/version
+    value: "${SCYLLA_DB_VERSION}"
+target:
+  group: scylla.scylladb.com
+  version: v1
+  kind: ScyllaCluster
+  name: scylla-manager-cluster
+EOF
+fi
+
+if [[ -n "${SCYLLA_MANAGER_VERSION:-}" ]]; then
+  cat << EOF | \
+  yq eval-all --inplace 'select(fileIndex == 0) as $f | select(fileIndex == 1) as $p | with( $f.patches; . += $p | ... style="") | $f' "${ARTIFACTS_DEPLOY_DIR}/manager/kustomization.yaml" -
+patch: |-
+  - op: replace
+    path: /spec/template/spec/containers/0/image
+    value: "docker.io/scylladb/scylla-manager:${SCYLLA_MANAGER_VERSION}"
+target:
+  group: apps
+  version: v1
+  kind: Deployment
+  name: scylla-manager
+EOF
+fi
+
+if [[ -n "${SCYLLA_MANAGER_AGENT_VERSION:-}" ]]; then
+  cat << EOF | \
+  yq eval-all --inplace 'select(fileIndex == 0) as $f | select(fileIndex == 1) as $p | with( $f.patches; . += $p | ... style="") | $f' "${ARTIFACTS_DEPLOY_DIR}/manager/kustomization.yaml" -
+patch: |-
+  - op: replace
+    path: /spec/agentVersion
+    value: "${SCYLLA_MANAGER_AGENT_VERSION}"
+target:
+  group: scylla.scylladb.com
+  version: v1
+  kind: ScyllaCluster
+  name: scylla-manager-cluster
+EOF
+fi
+
 kubectl kustomize "${ARTIFACTS_DEPLOY_DIR}/manager" | kubectl_create -n=scylla-manager -f=-
 
 kubectl -n=scylla-manager wait --timeout=5m --for='condition=Progressing=False' scyllaclusters.scylla.scylladb.com/scylla-manager-cluster

--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -113,6 +113,19 @@ if [[ -n "${SO_SCYLLACLUSTER_STORAGECLASS_NAME:-}" ]]; then
 elif [[ -n "${SO_SCYLLACLUSTER_STORAGECLASS_NAME+x}" ]]; then
   yq e --inplace 'del(.spec.datacenter.racks[0].storage.storageClassName)' "${DEPLOY_DIR}/manager/50_scyllacluster.yaml"
 fi
+
+if [[ -n "${SCYLLA_DB_VERSION:-}" ]]; then
+  yq e --inplace '.spec.version = env(SCYLLA_DB_VERSION)' "${DEPLOY_DIR}/manager/50_scyllacluster.yaml"
+fi
+
+if [[ -n "${SCYLLA_MANAGER_VERSION:-}" ]]; then
+  yq e --inplace '.spec.template.spec.containers[0].image |= "docker.io/scylladb/scylla-manager:" + env(SCYLLA_MANAGER_VERSION)' "${DEPLOY_DIR}/manager/50_manager_deployment.yaml"
+fi
+
+if [[ -n "${SCYLLA_MANAGER_AGENT_VERSION:-}" ]]; then
+  yq e --inplace '.spec.version = env(SCYLLA_MANAGER_AGENT_VERSION)' "${DEPLOY_DIR}/manager/50_scyllacluster.yaml"
+fi
+
 kubectl_create -f "${DEPLOY_DIR}"/manager
 
 kubectl -n=scylla-manager wait --timeout=10m --for='condition=Progressing=False' scyllaclusters.scylla.scylladb.com/scylla-manager-cluster

--- a/pkg/cmd/tests/options.go
+++ b/pkg/cmd/tests/options.go
@@ -55,6 +55,11 @@ type TestFrameworkOptions struct {
 	objectStorageType           framework.ObjectStorageType
 	gcsServiceAccountKey        []byte
 	s3CredentialsFile           []byte
+	ScyllaDBVersion             string
+	ScyllaManagerVersion        string
+	ScyllaManagerAgentVersion   string
+	ScyllaDBUpdateFrom          string
+	ScyllaDBUpgradeFrom         string
 }
 
 func NewTestFrameworkOptions(streams genericclioptions.IOStreams, userAgent string) *TestFrameworkOptions {
@@ -118,6 +123,11 @@ func (o *TestFrameworkOptions) AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVarP(&o.ObjectStorageBucket, "object-storage-bucket", "", o.ObjectStorageBucket, "Name of the object storage bucket.")
 	cmd.PersistentFlags().StringVarP(&o.GCSServiceAccountKeyPath, "gcs-service-account-key-path", "", o.GCSServiceAccountKeyPath, "Path to a file containing a GCS service account key.")
 	cmd.PersistentFlags().StringVarP(&o.S3CredentialsFilePath, "s3-credentials-file-path", "", o.S3CredentialsFilePath, "Path to the AWS credentials file providing access to the S3 bucket.")
+	cmd.PersistentFlags().StringVarP(&o.ScyllaDBVersion, "scylla-db-version", "", o.ScyllaDBVersion, "Version of ScyllaDB to use in tests.")
+	cmd.PersistentFlags().StringVarP(&o.ScyllaManagerVersion, "scylla-manager-version", "", o.ScyllaManagerVersion, "Version of Scylla Manager to use in tests.")
+	cmd.PersistentFlags().StringVarP(&o.ScyllaManagerAgentVersion, "scylla-manager-agent-version", "", o.ScyllaManagerAgentVersion, "Version of Scylla Manager Agent to use in tests.")
+	cmd.PersistentFlags().StringVarP(&o.ScyllaDBUpdateFrom, "scylla-update-from", "", o.ScyllaDBUpdateFrom, "Version of Scylla Update to use in tests.")
+	cmd.PersistentFlags().StringVarP(&o.ScyllaDBUpgradeFrom, "scylla-upgrade-from", "", o.ScyllaDBUpgradeFrom, "Version of Scylla Upgrade to use in tests.")
 }
 
 func (o *TestFrameworkOptions) Validate(args []string) error {
@@ -226,13 +236,18 @@ func (o *TestFrameworkOptions) Complete(args []string) error {
 		RestConfigs: slices.ConvertSlice(o.ClientConfigs, func(cc genericclioptions.ClientConfig) *rest.Config {
 			return cc.RestConfig
 		}),
-		ArtifactsDir:         o.ArtifactsDir,
-		CleanupPolicy:        o.CleanupPolicy,
-		ScyllaClusterOptions: o.scyllaClusterOptions,
-		ObjectStorageType:    o.objectStorageType,
-		ObjectStorageBucket:  o.ObjectStorageBucket,
-		GCSServiceAccountKey: o.gcsServiceAccountKey,
-		S3CredentialsFile:    o.s3CredentialsFile,
+		ArtifactsDir:              o.ArtifactsDir,
+		CleanupPolicy:             o.CleanupPolicy,
+		ScyllaClusterOptions:      o.scyllaClusterOptions,
+		ObjectStorageType:         o.objectStorageType,
+		ObjectStorageBucket:       o.ObjectStorageBucket,
+		GCSServiceAccountKey:      o.gcsServiceAccountKey,
+		S3CredentialsFile:         o.s3CredentialsFile,
+		ScyllaDBVersion:           o.ScyllaDBVersion,
+		ScyllaManagerVersion:      o.ScyllaManagerVersion,
+		ScyllaManagerAgentVersion: o.ScyllaManagerAgentVersion,
+		ScyllaDBUpdateFrom:        o.ScyllaDBUpdateFrom,
+		ScyllaDBUpgradeFrom:       o.ScyllaDBUpgradeFrom,
 	}
 
 	if o.IngressController != nil {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -49,6 +49,8 @@ var _ ClusterInterface = &Framework{}
 func NewFramework(namePrefix string) *Framework {
 	var err error
 
+	SetScyllaVersionsFromArgs()
+
 	f := &Framework{
 		name:            names.SimpleNameGenerator.GenerateName(fmt.Sprintf("%s-", namePrefix)),
 		e2eArtifactsDir: "",
@@ -130,6 +132,24 @@ func (f *Framework) CommonLabels() map[string]string {
 	return map[string]string{
 		"e2e":       "scylla-operator",
 		"framework": f.name,
+	}
+}
+
+func SetScyllaVersionsFromArgs() {
+	if version := TestContext.ScyllaDBVersion; version != "" {
+		configassets.Project.Operator.ScyllaDBVersion = version
+	}
+	if version := TestContext.ScyllaManagerVersion; version != "" {
+		configassets.Project.Operator.ScyllaDBManagerVersion = version
+	}
+	if version := TestContext.ScyllaManagerAgentVersion; version != "" {
+		configassets.Project.Operator.ScyllaDBManagerAgentVersion = version
+	}
+	if version := TestContext.ScyllaDBUpdateFrom; version != "" {
+		configassets.Project.OperatorTests.ScyllaDBVersions.UpdateFrom = version
+	}
+	if version := TestContext.ScyllaDBUpgradeFrom; version != "" {
+		configassets.Project.OperatorTests.ScyllaDBVersions.UpgradeFrom = version
 	}
 }
 

--- a/test/e2e/framework/testcontext.go
+++ b/test/e2e/framework/testcontext.go
@@ -43,13 +43,18 @@ const (
 )
 
 type TestContextType struct {
-	RestConfigs          []*restclient.Config
-	ArtifactsDir         string
-	CleanupPolicy        CleanupPolicyType
-	IngressController    *IngressController
-	ScyllaClusterOptions *ScyllaClusterOptions
-	ObjectStorageType    ObjectStorageType
-	ObjectStorageBucket  string
-	GCSServiceAccountKey []byte
-	S3CredentialsFile    []byte
+	RestConfigs               []*restclient.Config
+	ArtifactsDir              string
+	CleanupPolicy             CleanupPolicyType
+	IngressController         *IngressController
+	ScyllaClusterOptions      *ScyllaClusterOptions
+	ObjectStorageType         ObjectStorageType
+	ObjectStorageBucket       string
+	GCSServiceAccountKey      []byte
+	S3CredentialsFile         []byte
+	ScyllaDBVersion           string
+	ScyllaManagerVersion      string
+	ScyllaManagerAgentVersion string
+	ScyllaDBUpdateFrom        string
+	ScyllaDBUpgradeFrom       string
 }


### PR DESCRIPTION
**Description of your changes:**
Added the possibility to configure flags for ScyllaDB and Manager versions, allowing to test pre-released versions

**Which issue is resolved by this Pull Request:**
Resolves #2320
